### PR TITLE
Fix for Expression has no effect

### DIFF
--- a/src/front/public/script.app.js
+++ b/src/front/public/script.app.js
@@ -266,7 +266,7 @@
           version: 1,
         }));
       } catch {
-        undefined;
+        return;
       }
     }
 


### PR DESCRIPTION
To fix this, replace the useless expression in the `catch` block with an explicit early return (or an empty catch block with a comment). The best minimal fix that preserves behavior is to return from the function in the `catch` block, making the intent (“ignore storage errors and exit”) explicit and removing the no-effect expression.

Change only `src/front/public/script.app.js` in `saveCookieConsent(choice)`, specifically lines 268–270:
- Replace:
  - `} catch {`
  - `  undefined;`
  - `}`
- With:
  - `} catch {`
  - `  return;`
  - `}`

No imports, new methods, or new dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._